### PR TITLE
Implement automatic documentation generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       - 'release/**'
     types: [opened, reopened, edited, synchronize]
     paths:
-      - '**.js'
+      - '*.js'
       - 'test/**'
 jobs:
   coverage:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
     types: [opened, reopened, edited, synchronize]
     paths:
       - '*.js'
+      - 'modules/**'
       - 'test/**'
 jobs:
   coverage:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
     types: [opened, reopened, edited, synchronize]
     paths:
       - '**.js'
+      - 'test/**'
 jobs:
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/buildChrome.yml
+++ b/.github/workflows/buildChrome.yml
@@ -6,7 +6,7 @@ on:
       - 'release/**'
     types: [opened, reopened, edited, synchronize]
     paths:
-      - '**.js'
+      - '*.js'
       - 'test/**'
 jobs:
   buildChrome:

--- a/.github/workflows/buildChrome.yml
+++ b/.github/workflows/buildChrome.yml
@@ -3,11 +3,11 @@ on:
   pull_request:
     branches:
       - 'master'
-      - 'dev'
+      - 'release/**'
     types: [opened, reopened, edited, synchronize]
     paths:
       - '**.js'
-      - 'example/index.html'
+      - 'test/**'
 jobs:
   buildChrome:
     runs-on: ubuntu-latest

--- a/.github/workflows/buildChrome.yml
+++ b/.github/workflows/buildChrome.yml
@@ -7,6 +7,7 @@ on:
     types: [opened, reopened, edited, synchronize]
     paths:
       - '*.js'
+      - 'modules/**'
       - 'test/**'
 jobs:
   buildChrome:

--- a/.github/workflows/buildFF.yml
+++ b/.github/workflows/buildFF.yml
@@ -6,7 +6,7 @@ on:
       - 'release/**'
     types: [opened, reopened, edited, synchronize]
     paths:
-      - '**.js'
+      - '*.js'
       - 'test/**'
 jobs:
   buildFF:

--- a/.github/workflows/buildFF.yml
+++ b/.github/workflows/buildFF.yml
@@ -3,11 +3,11 @@ on:
   pull_request:
     branches:
       - 'master'
-      - 'dev'
+      - 'release/**'
     types: [opened, reopened, edited, synchronize]
     paths:
       - '**.js'
-      - 'example/index.html'
+      - 'test/**'
 jobs:
   buildFF:
     runs-on: ubuntu-latest

--- a/.github/workflows/buildFF.yml
+++ b/.github/workflows/buildFF.yml
@@ -7,6 +7,7 @@ on:
     types: [opened, reopened, edited, synchronize]
     paths:
       - '*.js'
+      - 'modules/**'
       - 'test/**'
 jobs:
   buildFF:

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -1,0 +1,31 @@
+name: generate-docs
+on:
+  push:
+    branches:
+      - 'master'
+      - 'release/**'
+    paths:
+      - '*.js'
+      - '!karma.conf.js'
+      - 'package.json'
+      - 'docs/**'
+jobs:
+  generate-docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: npm i
+    - name: Import GPG key
+      uses: crazy-max/ghaction-import-gpg@v2
+      with:
+        git_user_signingkey: true
+        git_commit_gpgsign: true
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_KEY }}
+        PASSPHRASE: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_PASSPHRASE }}
+    - name: Generate documentation
+      uses: kaskadi/action-generate-docs@master
+      with:
+        type: element
+        template: docs/template.md

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,8 @@ on:
       - 'master'
       - 'release/**'
     paths:
-      - '**.js'
+      - '*.js'
+      - '!karma.conf.js'
       - 'example/index.html'
       - 'package.json'
 env:
@@ -16,13 +17,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Install dependencies
       run: npm i
-    - uses: paambaati/codeclimate-action@v2.4.0
-      env:
-        CC_TEST_REPORTER_ID: ${{ secrets.REPORTER_ID }}
-      with:
-        coverageCommand: npm run coverage
+    - name: Test
+      run: npm test
     - name: Upload files to S3 bucket
       uses: kaskadi/action-s3cp@master

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,7 @@ on:
       - 'release/**'
     paths:
       - '*.js'
+      - 'modules/**'
       - '!karma.conf.js'
       - 'example/index.html'
       - 'package.json'

--- a/docs/template.md
+++ b/docs/template.md
@@ -1,0 +1,89 @@
+![](https://img.shields.io/github/package-json/v/kaskadi/template-kaskadi-element)
+![](https://img.shields.io/badge/code--style-standard-blue)
+![](https://img.shields.io/github/license/kaskadi/template-kaskadi-element?color=blue)
+
+[![](https://img.shields.io/badge/live-example-orange)](https://cdn.klimapartner.net/modules/%40kaskadi/template-kaskadi-element/example/index.html)
+
+**GitHub Actions workflows status**
+
+[![Build status](https://img.shields.io/github/workflow/status/kaskadi/template-kaskadi-element/build?label=build&logo=mocha)](https://github.com/kaskadi/template-kaskadi-element/actions?query=workflow%3Abuild)
+[![BuildFF status](https://img.shields.io/github/workflow/status/kaskadi/template-kaskadi-element/build-on-firefox?label=firefox&logo=Mozilla%20Firefox&logoColor=white)](https://github.com/kaskadi/template-kaskadi-element/actions?query=workflow%3Abuild-on-firefox)
+[![BuildChrome status](https://img.shields.io/github/workflow/status/kaskadi/template-kaskadi-element/build-on-chrome?label=chrome&logo=Google%20Chrome&logoColor=white)](https://github.com/kaskadi/template-kaskadi-element/actions?query=workflow%3Abuild-on-chrome)
+[![Publish status](https://img.shields.io/github/workflow/status/kaskadi/template-kaskadi-element/publish?label=publish&logo=Amazon%20AWS)](https://github.com/kaskadi/template-kaskadi-element/actions?query=workflow%3Apublish)
+[![Docs generation status](https://img.shields.io/github/workflow/status/kaskadi/template-kaskadi-element/generate-docs?label=docs&logo=read-the-docs)](https://github.com/kaskadi/template-kaskadi-element/actions?query=workflow%3Agenerate-docs)
+
+**CodeClimate**
+
+[![](https://img.shields.io/codeclimate/maintainability/kaskadi/template-kaskadi-element?label=maintainability&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/template-kaskadi-element)
+[![](https://img.shields.io/codeclimate/tech-debt/kaskadi/template-kaskadi-element?label=technical%20debt&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/template-kaskadi-element)
+[![](https://img.shields.io/codeclimate/coverage/kaskadi/template-kaskadi-element?label=test%20coverage&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/template-kaskadi-element)
+
+**LGTM**
+
+[![](https://img.shields.io/lgtm/grade/javascript/github/kaskadi/template-kaskadi-element?label=code%20quality&logo=LGTM)](https://lgtm.com/projects/g/kaskadi/template-kaskadi-element/?mode=list&logo=LGTM)
+
+<!-- You can add badges inside of this section if you'd like -->
+
+****
+
+# Testing
+
+`mocha`, `chai`, `standard` & `karma` are available as dev dependencies.
+
+A `build` workflow (see [here](./.github/workflows/build.yml)) along with individual [`build-on-chrome`](./.github/workflows/buildChrome.yml) and [`build-on-firefox`](./.github/workflows/buildFF.yml) workflows are running on `pull request` and will execute your test suite before allowing you to merge your PR. It also has a `coverage` job already prepared that you can comment out as soon as your testing is in place and your `REPORTER_ID` is in the repository secrets. This is the ID on _Code Climate_ used for uploading code coverage reports.
+
+****
+
+# Documentation
+
+This repository comes with a `generate-docs` workflow that generates documentation automatically for you using [`JSDOC`](https://jsdoc.app/). It'll check the element's file (found in the `main` field of `package.json`) for `JSDOC`-like comments in order to build its documentation. It also checks for any CSS custom variables and lists them in the documentation. See [here](https://github.com/kaskadi/action-generate-docs) and [there](./serverless.yml) for more information.
+
+If you would like to see the workflow configuration, head [here](./.github/workflows/generate-docs.yml).
+
+You can configure the template used to generate the action documentation [here](./docs/template.md).
+
+****
+
+# Publishing
+
+Publishing to CDN is done automatically via a `publish` workflow (see [here](./.github/workflows/publish.yml)). This workflow will run on `push` to `master`. It uses our internal action `action-s3cp` and a `kaskadi.s3-push` configuration field in `package.json`. See [here](https://github.com/kaskadi/action-s3cp) for more details on how to use this action.
+
+****
+
+<!-- automatically generated documentation will be placed in here -->
+{{>main}}
+<!-- automatically generated documentation will be placed in here -->
+
+# Translation modules <a name="translation-module"></a>
+
+This element also provides `lang` and `translate` as exports. Those two modules work in tandem and provide localization ability to an element.
+
+The `lang` module allows you to create a `lang` template string out of an object that defines multi-language localization for a sentence. It also handles regular strings.
+
+The `translate` module would translate a `lang` templated string into the desired language.
+
+_Notes:_:
+- if the language you're looking to translate to is unavailable (or if no language is provided), it would fall back to English.
+- you can also combine `lang` templated string with regular string to do partial translation.
+
+_Example:_
+```js
+const hello = {
+  en: 'hello',
+  de: 'hallo',
+  es: 'hola'
+}
+const s1 = lang`${hello}`
+console.log(translate(s1, 'de')) // prints out `hallo`
+console.log(translate(s1, 'fr')) // prints out `hello` because we don't know the french localization for `hello`
+console.log(translate(s1)) // prints out `hello` because we did not provide a language so it falls back to English
+
+const helloWorld = {
+  de: lang`${hello} Welt`,
+  en: lang`${hello} World`,
+  fr: lang`${hello} Monde`
+}
+const s2 = lang`${helloWorld}!`
+console.log(translate(s2, 'fr')) // prints out `hello Monde!` because we don't know the french localization for `hello`
+console.log(translate(s2, 'es')) // prints out `hola World!` because the Spanish localization for `hello` is `hola`
+```

--- a/kaskadi-element.js
+++ b/kaskadi-element.js
@@ -2,6 +2,44 @@
 import { css, html, LitElement } from 'https://cdn.klimapartner.net/modules/lit-element/lit-element.js'
 import { lang, translate } from './modules/translator.js'
 
+/**
+ * Base element for all Kaskadi elements.
+ *
+ * This does not render anything and is used for the sole purpose of bringing a set of properties and base utilities to every elements created in Kaskadi. Therefore **you should not use this element in the browser** but only as an import that is used for creating sub-classes on which custom elements are based.
+ *
+ * _Note:_ this module also exports `html`, `css` and `LitElement` from `lit-element` for further usage. It also exports its own localization modules `lang` and `translate`. See [here](#translation-module) for more information.
+ *
+ * @module KaskadiElement
+ *
+ * @param {string} [lang=en] - element's language
+ *
+ * @example
+ *
+ * import { lang, translate, KaskadiElement, css, html } from 'https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-element/kaskadi-element.js'
+ *
+ * class KaskadiCustomElement extends KaskadiElement {
+ *  constructor () {
+ *    super()
+ *    // initialize any properties of your element
+ *  }
+ *
+ *  static get properties () {
+ *    return {} // your properties
+ *  }
+ *
+ *  static get styles () {
+ *    return css`` // your styles
+ *  }
+ *
+ *  render () {
+ *    return html`` // your rendering function
+ *  }
+ * }
+ *
+ * customElements.define('kaskadi-custom-element', KaskadiCustomElement)
+ *
+ */
+
 class KaskadiElement extends LitElement {
   constructor () {
     super()

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,15 +1,10 @@
 /* eslint-env browser, mocha */
 import './test-element.js'
+
 describe('kaskadi-element', () => {
-  it('shou be usable as base class for custom elements', async () => {
-    // STRANGE BUG!!! MUST INVESTIGATE!!!
-    // try {
-    //   document.createElement('test-element')
-    // } catch (err) {
-    //   console.log('hi')
-    // }
-    document.body.innerHTML = '<test-element></test-element>'
-    const elem = document.querySelector('test-element')
+  it('should be usable as base class for custom elements', async () => {
+    const elem = document.createElement('test-element')
+    document.body.appendChild(elem)
     await elem.updateComplete
     elem.lang.should.equal('en')
   })

--- a/test/test-element.js
+++ b/test/test-element.js
@@ -3,7 +3,7 @@ import { KaskadiElement, html } from '../kaskadi-element.js'
 
 class TestElem extends KaskadiElement {
   render () {
-    return html`hi`
+    return html`<div>Hello</div>`
   }
 }
 customElements.define('test-element', TestElem)

--- a/test/translate.test.js
+++ b/test/translate.test.js
@@ -27,7 +27,7 @@ describe('translate', () => {
     translate(s1, 'fr').should.equal('hello')
     translate(s1).should.equal('hello')
   })
-  it('should work with nested tempalte strings', async () => {
+  it('should work with nested template strings', async () => {
     const s1 = {
       de: lang`${L.hello} Welt`,
       en: lang`${L.hello} World`,

--- a/test/translate.test.js
+++ b/test/translate.test.js
@@ -4,7 +4,7 @@ const L = {
   hello: {
     en: 'hello',
     de: 'hallo',
-    es: 'holla'
+    es: 'hola'
   }
 }
 describe('translate', () => {
@@ -18,7 +18,7 @@ describe('translate', () => {
     s1.length.should.equal(3)
     s1[1].en.should.equal('hello')
     s1[1].de.should.equal('hallo')
-    s1[1].es.should.equal('holla')
+    s1[1].es.should.equal('hola')
     translate(s1, 'de').should.equal('hallo')
     translate(s1, 'fr').should.equal('hello')
   })
@@ -44,6 +44,6 @@ describe('translate', () => {
     }
     const s2 = lang`${s1}!`
     translate(s2, 'fr').should.equal('hello Monde!') // hello unknown in frensh
-    translate(s2, 'es').should.equal('holla World!') // hello world phrase unknown in spanish but hello known in es
+    translate(s2, 'es').should.equal('hola World!') // hello world phrase unknown in spanish but hello known in es
   })
 })


### PR DESCRIPTION
**Changes description**
Implemented automatic documentation generation using `action-generate-docs` as GitHub action. Based off of a template located at `docs/template.md`. Also cleaned up code and fixed tests/workflows.

**New features**
- _`generate-docs` workflow:_ added `generate-docs` workflow which automatically generate documentation using `action-generate-docs` GitHub action and a template located under `docs/template.md`
- _documentation template:_ created template for documentation at `docs/template.md`

**Updated features**
- _build workflows:_ fixed triggers
- _`publish` workflow:_ fixed `publish` workflow triggers and coverage step
- _tests:_ fixed/cleaned up tests