### PR TITLE
Parallelized static code analysis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,6 @@ jobs:
       uses: github/codeql-action/analyze@v1
   coverage:
     runs-on: ubuntu-latest
-    needs: analyze
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies

--- a/.github/workflows/buildChrome.yml
+++ b/.github/workflows/buildChrome.yml
@@ -11,29 +11,8 @@ on:
       - 'modules/**'
       - 'test/**'
 jobs:
-  # scan code using CodeQL
-  analyze:
-    name: Analyze
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        language:
-          - 'javascript'
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: ${{ matrix.language }}
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
   buildChrome:
     runs-on: ubuntu-latest
-    needs: analyze
     steps:
     - uses: actions/checkout@v1
     - name: Test Chrome

--- a/.github/workflows/buildFF.yml
+++ b/.github/workflows/buildFF.yml
@@ -11,29 +11,8 @@ on:
       - 'modules/**'
       - 'test/**'
 jobs:
-  # scan code using CodeQL
-  analyze:
-    name: Analyze
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        language:
-          - 'javascript'
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: ${{ matrix.language }}
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
   buildFF:
     runs-on: ubuntu-latest
-    needs: analyze
     steps:
     - uses: actions/checkout@v1
     - name: Test Firefox

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,14 +35,20 @@ jobs:
       uses: github/codeql-action/autobuild@v1
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1
-  publish:
+  test:
     runs-on: ubuntu-latest
-    needs: analyze
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
       run: npm i
     - name: Test
       run: npm test
+  publish:
+    runs-on: ubuntu-latest
+    needs: [analyze, test]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: npm i
     - name: Upload files to S3 bucket
       uses: kaskadi/action-s3cp@master


### PR DESCRIPTION
**Changes description**
Switch from sequential to parallelized jobs in workflows containing static code analysis in order to speed up pipeline.

**Updated features**
- _`build`/`publish` workflows:_ parallelized static code analysis job. For browser specific build workflow, we will not perform a static code analysis (redundant)